### PR TITLE
update Random Generator with seed value to prevent conflicting Port

### DIFF
--- a/src/main/dot-net/Stumps.Base/NetworkInformation.cs
+++ b/src/main/dot-net/Stumps.Base/NetworkInformation.cs
@@ -43,7 +43,7 @@
                 }
             }
 
-            var rnd = new Random();
+            var rnd = new Random(Guid.NewGuid().GetHashCode());
 
             var foundPort = -1;
 


### PR DESCRIPTION
2018 Issue raised by Alec:
https://github.com/TSYS-Merchant/stumps/issues/97

When concurrent stumps instances are created on the same localhost they have a chance of incurring a HttpListenerException with conflicting Ports.

Example:
System.Net.HttpListenerException : Failed to listen on prefix 'http://*:7001/' because it conflicts with an existing registration on the machine.