### PR TITLE
add a ReTry engine for calling GetActiveTcpListeners

### DIFF
--- a/src/main/dot-net/Stumps.Base/NetworkInformation.cs
+++ b/src/main/dot-net/Stumps.Base/NetworkInformation.cs
@@ -112,10 +112,7 @@ namespace Stumps
                     }
 
                     attempt++;
-                    if(attempt <= 3)
-                    {
-                        continue;
-                    }
+                    continue;
                 }
             }
 

--- a/src/main/dot-net/Stumps.Base/NetworkInformation.cs
+++ b/src/main/dot-net/Stumps.Base/NetworkInformation.cs
@@ -1,4 +1,4 @@
-﻿namespace Stumps
+namespace Stumps
 {
     using System;
     using System.Net;
@@ -29,7 +29,7 @@
         public static int FindRandomOpenPort()
         {
             var properties = IPGlobalProperties.GetIPGlobalProperties();
-            var endpointList = properties.GetActiveTcpListeners();
+            var endpointList = ReTryGetActiveTcpListeners(properties);
 
             var usedPorts = new bool[NetworkInformation.MaximumPort - NetworkInformation.MinimumPort + 1];
 
@@ -88,6 +88,38 @@
             }
 
             return false;
+        }
+
+        private static IPEndPoint[] ReTryGetActiveTcpListeners(IPGlobalProperties properties)
+        {
+            int attempt = 1;
+            IPEndPoint[] response = null;
+            
+            while (attempt <= 3)
+            {
+                try
+                {
+                    response = properties.GetActiveTcpListeners();
+                    return response;
+                }
+                catch(Exception ex)
+                {
+                    Console.WriteLine(ex);
+
+                    if(!(ex is NetworkInformationException))
+                    {
+                        return response;
+                    }
+
+                    attempt++;
+                    if(attempt <= 3)
+                    {
+                        continue;
+                    }
+                }
+            }
+
+            return response;
         }
     }
 }

--- a/src/main/dot-net/Stumps.Base/NetworkInformation.cs
+++ b/src/main/dot-net/Stumps.Base/NetworkInformation.cs
@@ -95,7 +95,7 @@ namespace Stumps
             int attempt = 1;
             IPEndPoint[] response = null;
             
-            while (attempt <= 3)
+            while (attempt <= 10)
             {
                 try
                 {


### PR DESCRIPTION
[2021-09-06T14:11:52.469Z]    System.Net.NetworkInformation.NetworkInformationException : Unknown error (0xc0000001)
[2021-09-06T14:11:52.469Z]    at System.Net.NetworkInformation.SystemIPGlobalProperties.GetAllTcpConnections()
[2021-09-06T14:11:52.469Z]    at System.Net.NetworkInformation.SystemIPGlobalProperties.GetActiveTcpListeners()
[2021-09-06T14:11:52.469Z]    at Stumps.NetworkInformation.FindRandomOpenPort()
[2021-09-06T14:11:52.469Z]    at Stumps.StumpsServer..ctor()

concurrency exception with too many updates to the TCP IP Table.
https://github.com/dotnet/runtime/issues/29560