### PR TITLE
update NetworkInformation class for slight delay

### DIFF
--- a/src/main/dot-net/Stumps.Base/NetworkInformation.cs
+++ b/src/main/dot-net/Stumps.Base/NetworkInformation.cs
@@ -3,6 +3,7 @@ namespace Stumps
     using System;
     using System.Net;
     using System.Net.NetworkInformation;
+    using System.Threading;
 
     /// <summary>
     ///     A class that represents a set of Network related functions.
@@ -104,14 +105,15 @@ namespace Stumps
                 }
                 catch(Exception ex)
                 {
-                    Console.WriteLine(ex);
-
                     if(!(ex is NetworkInformationException))
                     {
+                        Console.WriteLine(ex);
                         return response;
                     }
 
                     attempt++;
+                    Thread.Sleep(TimeSpan.FromMilliseconds(10));
+                    
                     continue;
                 }
             }


### PR DESCRIPTION
updated the method ReTryGetActiveTcpListeners for a slight delay between ReTry attempts and removed the initial logging of the exception message for all NetworkInformationException's